### PR TITLE
AVX-25383 mc-gateway Advanced Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The following variables are optional:
 | :------------: | :------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
 |  insane_mode   |  AWS<br>Azure  |     false     |                                       Set to true to enable Aviatrix high performance encryption                                        |
 | single_ip_snat |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
-
+|       num_of_subnet_pairs       |      AWS, Azure       |          | Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider |
+|       subnet_size               |      AWS, Azure       |          | Subnet Size. Only Supported for AWS, Azure Provider |
+|       resource_group            |      Azure       |          | Resource Group of the Azure VPC created |
 ### VPN options
 |       Attribute        |   Supported CSPs    |  Default value  |                                                                     Description                                                                      |
 | :--------------------: | :-----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ The following variables are optional:
 | :------------: | :------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
 |  insane_mode   |  AWS<br>Azure  |     false     |                                       Set to true to enable Aviatrix high performance encryption                                        |
 | single_ip_snat |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
-|       num_of_subnet_pairs       |      AWS, Azure       |          | Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider |
-|       subnet_size               |      AWS, Azure       |          | Subnet Size. Only Supported for AWS, Azure Provider |
-|       resource_group            |      Azure       |          | Resource Group of the Azure VPC created |
+| num_of_subnet_pairs |   AWS, Azure   |               |                        Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider                        |
+|     subnet_size     |   AWS, Azure   |               |                                           Subnet Size. Only Supported for AWS, Azure Provider                                           |
+|   resource_group    |     Azure      |               |                         Name of an existing resource group or a new resource group to be created for Azure VNet                         |
 ### VPN options
 |       Attribute        |   Supported CSPs    |  Default value  |                                                                     Description                                                                      |
 | :--------------------: | :-----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # terraform-aviatrix-mc-gateway
 
 ## Description
+
 Deploys a VPC/VNet/VCN and Aviatrix gateway. It is also possible to use an existing VPC/VNet/VCN.
 
 ## Compatibility
+
 | Module version | Terraform version | Controller version | Terraform provider version |
 | :------------: | :---------------: | :----------------: | :------------------------: |
 |     v1.0.2     |     >=1.0         |       >=6.7        |          ~>2.22.0          |
@@ -13,6 +15,7 @@ Deploys a VPC/VNet/VCN and Aviatrix gateway. It is also possible to use an exist
 - Check [release notes](https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-gateway/blob/master/RELEASE_NOTES.md) for more details.
 
 ## Usage examples
+
 See [examples](https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-gateway/blob/main/examples/)
 
 ## Variables
@@ -32,6 +35,7 @@ The following variables are required:
 The following variables are optional:
 
 ### HA options
+
 |       Attribute        | Supported CSPs |                        Default value                         |                                           Description                                            |
 | :--------------------: | :------------: | :----------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |
 |     instance_size      |      ALL       | t3.small<br>n1-standard-1<br>Standard_B1ms<br>VM.Standard2.2 |                                Instance size for Aviatrix gateway                                |
@@ -43,6 +47,7 @@ The following variables are optional:
 |       ha_region        |      GCP       |                                                              | Region for multi-region HA. Secondary GCP region where subnet and HA gateway will be launched in |
 
 ### GW options
+
 |       Attribute       |   Supported CSPs    | Default value  |                                                Description                                                 |
 | :-------------------: | :-----------------: | :------------: | :--------------------------------------------------------------------------------------------------------: |
 |   use_existing_vpc    |         ALL         |     false      |                        Set to true to use an existing VPC instead of launching one                         |
@@ -57,14 +62,17 @@ The following variables are optional:
 |      az_support       |        Azure        |      true      |                                 Set to true if Azure region supports AZ's                                  |
 
 ### Advanced options
-|   Attribute    | Supported CSPs | Default value |                                                               Description                                                               |
-| :------------: | :------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
-|  insane_mode   |  AWS<br>Azure  |     false     |                                       Set to true to enable Aviatrix high performance encryption                                        |
-| single_ip_snat |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
-| num_of_subnet_pairs |   AWS, Azure   |               |                        Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider                        |
-|     subnet_size     |   AWS, Azure   |               |                                           Subnet Size. Only Supported for AWS, Azure Provider                                           |
-|   resource_group    |     Azure      |               |                         Name of an existing resource group or a new resource group to be created for Azure VNet                         |                     |
+
+|      Attribute      | Supported CSPs | Default value |                                                               Description                                                               |
+| :-----------------: | :------------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
+|     insane_mode     |  AWS<br>Azure  |     false     |                                       Set to true to enable Aviatrix high performance encryption                                        |
+|   single_ip_snat    |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
+| num_of_subnet_pairs |      ALL       |               |                        Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider                        |
+|     subnet_size     |      ALL       |               |                                           Subnet Size. Only Supported for AWS, Azure Provider                                           |
+|   resource_group    |      ALL       |               |                         Name of an existing resource group or a new resource group to be created for Azure VNet                         |
+
 ### VPN options
+
 |       Attribute        |   Supported CSPs    |  Default value  |                                                                     Description                                                                      |
 | :--------------------: | :-----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |
 |       enable_vpn       |         ALL         |      false      |                                            Set to true to enable user access through VPN to this gateway                                             |
@@ -77,8 +85,8 @@ The following variables are optional:
 | renegotiation_interval |         ALL         |       -1        | Value (in seconds) of the renegotiation interval. If set, must be greater than 300; if unset, this feature is disabled. Only for VPN-enabled gateway |
 |     saml_enabled       |         ALL         |      false      |                                                                  Enable/disable SAML.                                                                |
 
-
 #### Split Tunnel options
+
 |        Attribute         | Supported CSPs | Default value |                                                                                 Description                                                                                  |
 | :----------------------: | :------------: | :-----------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | enable_split_tunnel_mode |      ALL       |     true      |                                               Set to true to enable Split Tunnel Mode. Only available for VPN-enabled gateways                                               |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following variables are optional:
 | single_ip_snat |      ALL       |     false     | Set to true to enable Source NAT feature in single_ip mode on the gateway. Please disable AWS NAT instance before enabling this feature |
 | num_of_subnet_pairs |   AWS, Azure   |               |                        Number of public subnet and private subnet pair created. Only Support AWS, Azure Provider                        |
 |     subnet_size     |   AWS, Azure   |               |                                           Subnet Size. Only Supported for AWS, Azure Provider                                           |
-|   resource_group    |     Azure      |               |                         Name of an existing resource group or a new resource group to be created for Azure VNet                         |
+|   resource_group    |     Azure      |               |                         Name of an existing resource group or a new resource group to be created for Azure VNet                         |                     |
 ### VPN options
 |       Attribute        |   Supported CSPs    |  Default value  |                                                                     Description                                                                      |
 | :--------------------: | :-----------------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: |
@@ -76,6 +76,7 @@ The following variables are optional:
 |      idle_timeout      |         ALL         |       -1        |        Value (in seconds) of idle timeout. If set, must be greater than 300; if unset, this feature is disabled. Only for VPN-enabled gateway        |
 | renegotiation_interval |         ALL         |       -1        | Value (in seconds) of the renegotiation interval. If set, must be greater than 300; if unset, this feature is disabled. Only for VPN-enabled gateway |
 |     saml_enabled       |         ALL         |      false      |                                                                  Enable/disable SAML.                                                                |
+
 
 #### Split Tunnel options
 |        Attribute         | Supported CSPs | Default value |                                                                                 Description                                                                                  |

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,9 @@ resource "aviatrix_vpc" "default" {
   cidr         = local.cloud == "gcp" ? null : var.cidr
   name         = local.name
 
-  # subnet_size = 
-  # num_subnet_pairs = 
-  # resource_group = 
-
+  subnet_size         = local.subnet_size
+  resource_group      = var.resource_group
+  num_of_subnet_pairs = local.num_of_subnet_pairs
   dynamic "subnets" {
     for_each = local.cloud == "gcp" ? ["dummy"] : [] # Workaround to make block conditional. Count not available on dynamic blocks
     content {
@@ -55,8 +54,7 @@ resource "aviatrix_gateway" "default" {
   customer_managed_keys = local.customer_managed_keys
   tags                  = var.tags
 
-  single_ip_snat = var.single_ip_snat
-
+  single_ip_snat            = var.single_ip_snat
   insane_mode               = var.insane_mode
   insane_mode_az            = local.insane_mode_az
   peering_ha_insane_mode_az = var.enable_ha ? local.ha_insane_mode_az : null

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,9 @@ resource "aviatrix_vpc" "default" {
   cidr         = local.cloud == "gcp" ? null : var.cidr
   name         = local.name
 
-  subnet_size         = local.subnet_size
+  subnet_size         = var.subnet_size
   resource_group      = var.resource_group
-  num_of_subnet_pairs = local.num_of_subnet_pairs
+  num_of_subnet_pairs = var.num_of_subnet_pairs
   dynamic "subnets" {
     for_each = local.cloud == "gcp" ? ["dummy"] : [] # Workaround to make block conditional. Count not available on dynamic blocks
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -186,6 +186,24 @@ variable "single_ip_snat" {
   default     = false
 }
 
+variable "subnet_size" {
+  description = "Size of each cidr block in bits"
+  type        = number
+  default     = null
+}
+
+variable "num_of_subnet_pairs" {
+  description = "Number of public subnet and private subnet pair created in the VPC"
+  type        = number
+  default     = null
+}
+
+variable "resource_group" {
+  description = "The name of an existing resource group or a new resource group to be created for the Azure VNet"
+  type        = string
+  default     = ""
+}
+
 ## VPN options
 variable "enable_vpn" {
   description = "Set to true to enable user access through VPN to this gateway"
@@ -325,6 +343,18 @@ locals {
     gcp   = "n1-standard-1",
     azure = "Standard_B1ms",
     oci   = "VM.Standard2.2"
+  }
+
+  num_of_subnet_pairs = var.num_of_subnet_pairs != null ? var.num_of_subnet_pairs : lookup(local.num_of_subnet_pairs_map, local.cloud, null)
+  num_of_subnet_pairs_map = {
+    azure = 2,
+    aws   = 2,
+  }
+
+  subnet_size = var.subnet_size != null ? var.subnet_size : lookup(local.subnet_size_map, local.cloud, null)
+  subnet_size_map = {
+    azure = 28,
+    aws   = 28,
   }
 
   az1 = length(var.az1) > 0 ? var.az1 : lookup(local.az1_map, local.cloud, null)

--- a/variables.tf
+++ b/variables.tf
@@ -345,18 +345,6 @@ locals {
     oci   = "VM.Standard2.2"
   }
 
-  num_of_subnet_pairs = var.num_of_subnet_pairs != null ? var.num_of_subnet_pairs : lookup(local.num_of_subnet_pairs_map, local.cloud, null)
-  num_of_subnet_pairs_map = {
-    azure = 2,
-    aws   = 2,
-  }
-
-  subnet_size = var.subnet_size != null ? var.subnet_size : lookup(local.subnet_size_map, local.cloud, null)
-  subnet_size_map = {
-    azure = 28,
-    aws   = 28,
-  }
-
   az1 = length(var.az1) > 0 ? var.az1 : lookup(local.az1_map, local.cloud, null)
   az1_map = {
     aws   = "a",


### PR DESCRIPTION
# New

Add the following input options to this module for the VPC:
- subnet_size
- num_of_subnet_pairs
- resource_group
[Reference]: https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/resources/aviatrix_vpc#advanced-options 
[Source Code]:  https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-gateway